### PR TITLE
Add test/lint tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements.txt
+      - run: make test
+      - run: make lint

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: test lint
+
+test:
+	pytest -q || test $$? -eq 5
+
+lint:
+	ruff check .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+ruff


### PR DESCRIPTION
## Summary
- add `Makefile` with `test` and `lint` targets
- install dev dependencies via `requirements.txt`
- run the targets on pull requests in a new CI workflow

## Testing
- `pip install -r requirements.txt`
- `make test && make lint`


------
https://chatgpt.com/codex/tasks/task_b_6877b19e4c708326ad0f3d50d15d90b1