### PR TITLE
Add FastAPI dice roller

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ Expected response:
 }
 ```
 
+### Quick Start (Local)
+
+```bash
+python main.py
+```
+
+
 ## API Reference
 
 ### POST /roll

--- a/main.py
+++ b/main.py
@@ -1,0 +1,6 @@
+from mcp_dice import app
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/mcp_dice/__init__.py
+++ b/mcp_dice/__init__.py
@@ -1,0 +1,4 @@
+from .api import app
+from .dice import roll, RollResult
+
+__all__ = ["app", "roll", "RollResult"]

--- a/mcp_dice/api.py
+++ b/mcp_dice/api.py
@@ -1,0 +1,29 @@
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from pydantic import BaseModel
+
+from .dice import roll, RollResult
+
+
+class RollRequest(BaseModel):
+    expression: str
+    seed: str | None = None
+
+
+app = FastAPI()
+
+
+@app.post("/roll")
+async def post_roll(req: RollRequest) -> RollResult:
+    return roll(req.expression, req.seed)
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(ws: WebSocket) -> None:
+    await ws.accept()
+    try:
+        while True:
+            expr = await ws.receive_text()
+            result = roll(expr)
+            await ws.send_json(result.__dict__)
+    except WebSocketDisconnect:
+        pass

--- a/mcp_dice/dice.py
+++ b/mcp_dice/dice.py
@@ -1,0 +1,49 @@
+import random
+import re
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass
+class RollResult:
+    expression: str
+    dice: List[int]
+    used: List[int]
+    modifier: int
+    total: int
+    seed: Optional[str] = None
+
+
+def roll(expression: str, seed: Optional[str] = None) -> RollResult:
+    """Roll dice based on a minimal NdM(+/-K) expression."""
+    pattern = re.compile(r"^(\d+)d(\d+)(kh\d+|kl\d+)?([+-]\d+)?$")
+    match = pattern.match(expression.replace(" ", ""))
+    if not match:
+        raise ValueError("Invalid expression")
+
+    count = int(match.group(1))
+    sides = int(match.group(2))
+    keep_drop = match.group(3)
+    modifier = int(match.group(4) or 0)
+
+    rng = random.Random(seed)
+    dice = [rng.randint(1, sides) for _ in range(count)]
+
+    used = dice[:]
+    if keep_drop:
+        action = keep_drop[:2]
+        num = int(keep_drop[2:])
+        if action == "kh":
+            used = sorted(dice, reverse=True)[:num]
+        elif action == "kl":
+            used = sorted(dice)[:num]
+
+    total = sum(used) + modifier
+    return RollResult(
+        expression=expression,
+        dice=dice,
+        used=used,
+        modifier=modifier,
+        total=total,
+        seed=seed,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
+fastapi
+uvicorn
 pytest
 ruff

--- a/tests/test_dice.py
+++ b/tests/test_dice.py
@@ -1,0 +1,22 @@
+import pytest
+from mcp_dice import roll
+
+
+def test_deterministic_seed() -> None:
+    result1 = roll("2d6+1", seed="test")
+    result2 = roll("2d6+1", seed="test")
+    assert result1.dice == result2.dice
+    assert result1.total == result2.total
+
+
+def test_keep_highest() -> None:
+    result = roll("4d6kh3", seed="seed")
+    assert len(result.dice) == 4
+    assert len(result.used) == 3
+    assert result.total == sum(sorted(result.dice, reverse=True)[:3])
+
+
+
+def test_invalid_expression() -> None:
+    with pytest.raises(ValueError):
+        roll("bad")


### PR DESCRIPTION
## Summary
- implement minimal FastAPI app with REST and WebSocket endpoints
- add deterministic dice roller and expose via API
- provide CLI entry in `main.py`
- document local quick start and update dependencies
- add unit tests for dice mechanics

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_6877b3d271708326bc311c4046f5246b