### PR TITLE
Add dice grammar doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ WebSocket endpoint. Send plaintext expressions; receive one-line JSON results—
 | Parentheses | Nest expressions | `(2d6+1)d4` |
 | Comments | `//` ignored to line end | `3d6 // str` |
 
-Full grammar lives in `docs/grammar.md`.
+Full grammar lives in [docs/grammar.md](docs/grammar.md).
 
 ## Configuration
 

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -1,0 +1,34 @@
+# Dice Expression Grammar
+
+The dice roller accepts a variant of standard tabletop dice notation. Expressions are evaluated left to right and may be nested with parentheses. Whitespace is ignored and lines may contain trailing `//` comments.
+
+```
+EXPR      ::= TERM ( ("+" | "-") TERM )*
+TERM      ::= FACTOR ("d" FACTOR)?
+FACTOR    ::= NUMBER | GROUP
+GROUP     ::= "(" EXPR ")"
+NUMBER    ::= [0-9]+
+```
+
+When rolling dice (`NdX`), optional suffixes modify the roll:
+
+```
+ROLL      ::= NUMBER "d" NUMBER MODIFIERS?
+MODIFIERS ::= (KEEPDROP | EXPLODE | REROLL)*
+KEEPDROP  ::= ("kh"|"kl"|"dh"|"dl") NUMBER
+EXPLODE   ::= "!"
+REROLL    ::= "r<" NUMBER | "r>" NUMBER
+```
+
+- `khN` / `klN` – keep the highest or lowest N dice
+- `dhN` / `dlN` – drop the highest or lowest N dice
+- `!` – exploding dice; roll again and add while the die shows its maximum value
+- `r<N` / `r>N` – reroll once if the die is below/above the threshold
+
+### Examples
+
+- `4d6kh3` – roll four six-sided dice and keep the best three
+- `2d20kl1!` – roll two d20, keep the lowest one, and explode on 20s
+- `5d10r<3dl1` – roll five d10, reroll any results under 3 once, then drop the lowest die
+- `(2d6+1)d4` – nest expressions: roll two d6 plus one, then roll that many d4
+- `3d6 // ability score` – comments after `//` are ignored


### PR DESCRIPTION
## Summary
- add detailed dice notation grammar under `docs/`
- link new grammar file from README

## Testing
- `make test`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_b_6877b7fe139c832682914f034cbd2cbf